### PR TITLE
Envoy.yaml: Use BitRAW-specific container hostnames

### DIFF
--- a/docker/envoy.yaml
+++ b/docker/envoy.yaml
@@ -1,6 +1,6 @@
 admin:
   address:
-    socket_address: {address: 0.0.0.0, port_value: 9901}
+    socket_address: {address: 127.0.0.1, port_value: 9901}
 
 static_resources:
   listeners:

--- a/docker/envoy.yaml
+++ b/docker/envoy.yaml
@@ -59,7 +59,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 0.0.0.0
+                address: dingir-matchengine
                 port_value: 50051
 
   - name: rust_http
@@ -78,5 +78,5 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 0.0.0.0
+                address: dingir-restapi
                 port_value: 50053


### PR DESCRIPTION
@rlack is this all the settings we need to be changed?

Once merged, could you change the cloud environment to use `orchestra/docker/envoy.yaml` instead of `kubernetes/envoy.yaml`?